### PR TITLE
import sirupsen/logrus with lowercase name

### DIFF
--- a/lock.go
+++ b/lock.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // Mutex is debugging mutex, which prints logs and traces for locks.

--- a/lock_test.go
+++ b/lock_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func init() {


### PR DESCRIPTION
The import path of logrus has been changed, the uppercase S has been replaced with a lowercase s. See the first paragraph of their [README](https://github.com/sirupsen/logrus/blob/master/README.md).

Keeping the upper-case import breaks Go Modules in projects that use both `debugmutex` and other packages which also import logrus.

As can be read [here](https://github.com/sirupsen/logrus/issues/570), the final name will stay lower-cased.